### PR TITLE
fix(doc): update ICAP address link

### DIFF
--- a/docs/v5/api/utils/address/README.md
+++ b/docs/v5/api/utils/address/README.md
@@ -28,7 +28,7 @@ The value of *address* may be any supported address format.
 
 #### *ethers* . *utils* . **getIcapAddress**( address ) => *string< [IcapAddress](/v5/api/utils/address/#address-icap) >*
 
-Returns *address* as an [ICAP address](https://github.com/ethereum/wiki/wiki/Inter-exchange-Client-Address-Protocol-%28ICAP%29). Supports the same restrictions as [getAddress](/v5/api/utils/address/#utils-getAddress).
+Returns *address* as an [ICAP address](https://eth.wiki/en/ideas/inter-exchange-client-address-protocol-icap). Supports the same restrictions as [getAddress](/v5/api/utils/address/#utils-getAddress).
 
 
 #### *ethers* . *utils* . **isAddress**( address ) => *boolean*


### PR DESCRIPTION
https://github.com/ethereum/wiki is deprecated and replaced to the current link